### PR TITLE
Fix uploadImage endpoint

### DIFF
--- a/frontend/src/components/utils.js
+++ b/frontend/src/components/utils.js
@@ -1,5 +1,7 @@
 import axios from "axios";
 
+const backendUrl = process.env.REACT_APP_BACKEND_URL;
+
 // utils.js
 
 
@@ -18,7 +20,7 @@ export const uploadImage = async (imageFile, token) => {
     formData.append('image', imageFile);
 
     const response = await axios.post(
-        'http://localhost:5000/api/recipes/upload',
+        `${backendUrl}/api/recipes/upload`,
         formData,
         {
             headers: { Authorization: `Bearer ${token}` },


### PR DESCRIPTION
## Summary
- use environment variable for backend URL in `uploadImage`

## Testing
- `npm test -- -w=0` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_684028d04c888326a354aa8d6e1cb6c6